### PR TITLE
ユーザー作成画面のデザイン修正

### DIFF
--- a/frontend/src/components/pages/Register.vue
+++ b/frontend/src/components/pages/Register.vue
@@ -43,7 +43,7 @@
             <dt class="mail_address">Mail Address</dt>
             <dd>
               <input
-                type="email"
+                type="text"
                 name="mail_address"
                 placeholder="Mail Address"
                 id="mail_address"
@@ -54,7 +54,7 @@
             <dt class="password">Password</dt>
             <dd>
               <input
-                type="password"
+                type="text"
                 name="password"
                 placeholder="Password"
                 id="password"
@@ -139,6 +139,11 @@ form dl dd input {
 }
 input::placeholder {
   color: #c0c0c0;
+}
+.register_form input[type=text] {
+  background-color: #eee;
+  color: #777;
+  border: none;
 }
 .button {
   display: block;

--- a/frontend/src/components/pages/Register.vue
+++ b/frontend/src/components/pages/Register.vue
@@ -43,7 +43,7 @@
             <dt class="mail_address">Mail Address</dt>
             <dd>
               <input
-                type="text"
+                type="email"
                 name="mail_address"
                 placeholder="Mail Address"
                 id="mail_address"
@@ -52,15 +52,18 @@
               />
             </dd>
             <dt class="password">Password</dt>
-            <dd>
+            <dd class="input-password">
               <input
-                type="text"
+                :type="showPassword ? 'text' : 'password'"
                 name="password"
                 placeholder="Password"
                 id="password"
                 v-model="password"
                 required
               />
+              <span class="eye-icon">
+                <img :src="eyeImage" @click="showPassword = !showPassword" />
+              </span>
             </dd>
           </dl>
           <div class="submit">
@@ -73,6 +76,9 @@
 </template>
 
 <script>
+import eyeOpenImage from '@/assets/img/eye-open.png'
+import eyeCloseImage from '@/assets/img/eye-close.png'
+
 export default {
   name: 'Register',
   data () {
@@ -81,7 +87,13 @@ export default {
       firstName: '',
       lastName: '',
       email: '',
-      password: ''
+      password: '',
+      showPassword: false
+    }
+  },
+  computed: {
+    eyeImage () {
+      return this.showPassword ? eyeCloseImage : eyeOpenImage
     }
   }
 }
@@ -140,10 +152,21 @@ form dl dd input {
 input::placeholder {
   color: #c0c0c0;
 }
-.register_form input[type=text] {
+.register_form input[type=text],
+.register_form input[type=email],
+.register_form input[type=password] {
   background-color: #eee;
   color: #777;
   border: none;
+}
+.input-password {
+  position: relative;
+}
+.eye-icon {
+  position: absolute;
+  right:22px;
+  bottom: 2px;
+  cursor: pointer;
 }
 .button {
   display: block;

--- a/frontend/src/components/pages/Register.vue
+++ b/frontend/src/components/pages/Register.vue
@@ -14,7 +14,7 @@
                 name="user_name"
                 placeholder="User Name"
                 id="user_name"
-                v-model="userName"
+                v-model="nickname"
                 required
               />
             </dd>
@@ -43,7 +43,7 @@
             <dt class="mail_address">Mail Address</dt>
             <dd>
               <input
-                type="text"
+                type="email"
                 name="mail_address"
                 placeholder="Mail Address"
                 id="mail_address"
@@ -51,10 +51,10 @@
                 required
               />
             </dd>
-            <dt class="pssword">Password</dt>
+            <dt class="password">Password</dt>
             <dd>
               <input
-                type="text"
+                type="password"
                 name="password"
                 placeholder="Password"
                 id="password"
@@ -77,7 +77,7 @@ export default {
   name: 'Register',
   data () {
     return {
-      userName: '',
+      nickname: '',
       firstName: '',
       lastName: '',
       email: '',


### PR DESCRIPTION
# TODO
- [ ] `input`要素のデザインをログイン画面と揃える
- [ ] 目のアイコンで`text`属性を切り替える